### PR TITLE
Add OgnFilter: message deduplication and aircraft data cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Source files
 set(SOURCES
+    lib/OgnFilter.cpp
     lib/OgnParser.cpp
 )
 
 # Header files
 set(HEADERS
+    lib/OgnFilter.h
     lib/OgnParser.h
 )
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A lightweight parser library for the [Open Glider Network](https://www.glidernet
 The library is organized as follows:
 
 - **lib/**: Core library (Qt-free, C++17 only)
-  - `OgnParser.h` - Public API
-  - `OgnParser.cpp` - Implementation
+  - `OgnParser.h` / `OgnParser.cpp` - Parses APRS-IS sentences into `OgnMessage` structs
+  - `OgnFilter.h` / `OgnFilter.cpp` - Filters out messages with outdated timestamps and enriches them with cached aircraft type information
 - **tests/**: Unit tests (uses CTest)
 - **dumpOGN/**: Utility for dumping OGN data 
 

--- a/dumpOGN/dumpOGN.cpp
+++ b/dumpOGN/dumpOGN.cpp
@@ -29,6 +29,7 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #include "OgnParser.h"
+#include "OgnFilter.h"
 #include "OgnFormatter.h"
 #include "SBS1Formatter.h"
 
@@ -215,6 +216,9 @@ int main(int argc, char *argv[])
     OutputFormatter* formatter = sbs1Mode ? static_cast<OutputFormatter*>(&sbs1Formatter) 
                                           : static_cast<OutputFormatter*>(&ognFormatter);
 
+    // Filter to suppress duplicate and out-of-order messages
+    Ogn::OgnFilter filter;
+
     // Read and process messages
     std::string buffer;
     std::string line;
@@ -223,7 +227,12 @@ int main(int argc, char *argv[])
         Ogn::OgnMessage message;
         message.sentence = line;
         Ogn::OgnParser::parseAprsisMessage(message);
-        
+
+        // Skip messages that are not new (older or equal timestamp to cached data)
+        if (!filter.filter(message)) {
+            continue;
+        }
+
         // Format using the configured formatter
         const std::string output = formatter->format(message);
         if (!output.empty()) {

--- a/lib/OgnFilter.cpp
+++ b/lib/OgnFilter.cpp
@@ -1,0 +1,113 @@
+/***************************************************************************
+ *   Copyright (C) 2021-2025 by Stefan Kebekus                             *
+ *   stefan.kebekus@gmail.com                                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "OgnFilter.h"
+
+#include <chrono>
+#include <cmath>
+
+namespace Ogn {
+
+void OgnCache::update(const OgnMessage& msg)
+{
+    // Only process traffic reports with a valid aircraft identifier
+    if (msg.type != OgnMessageType::TRAFFIC_REPORT) {
+        return;
+    }
+    if (msg.aircraftID.empty()) {
+        return;
+    }
+
+    // find() with std::less<> accepts string_view directly — no string allocation.
+    // Only convert to std::string when we actually need to insert a new key.
+    auto it = m_cache.find(msg.aircraftID);
+    const bool inserted = (it == m_cache.end());
+    if (inserted) {
+        it = m_cache.emplace(std::string(msg.aircraftID), OgnData{}).first;
+    } else {
+        // Reject if not strictly newer than what is already cached
+        if (msg.timestamp <= it->second.timestamp) {
+            return;
+        }
+    }
+    OgnData& entry = it->second;
+
+    // --- Timestamp ----------------------------------------------------------
+    entry.timestamp = msg.timestamp;
+
+    // --- Aircraft identification (skip unknown / default values) -------------
+    if (msg.aircraftType != OgnAircraftType::unknown) {
+        entry.aircraftTypes.insert(msg.aircraftType);
+    }
+    if (msg.addressType != OgnAddressType::UNKNOWN) {
+        entry.addressTypes.insert(msg.addressType);
+    }
+}
+
+void OgnCache::clean()
+{
+    auto now = std::chrono::system_clock::now();
+    auto one_hour_ago = now - std::chrono::hours(1);
+
+    for (auto it = m_cache.begin(); it != m_cache.end(); ) {
+        if (it->second.timestamp < one_hour_ago) {
+            it = m_cache.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+bool OgnFilter::filter(OgnMessage& msg)
+{
+    // Only process traffic reports
+    if (msg.type != OgnMessageType::TRAFFIC_REPORT) {
+        return false;
+    }
+    if (msg.aircraftID.empty()) {
+        return false;
+    }
+
+    // Heterogeneous lookup: find() accepts string_view without allocating a temporary string.
+    const auto& cache_data = m_cache.data();
+    auto it = cache_data.find(msg.aircraftID);
+    if (it != cache_data.end()) {
+        const OgnData& cached = it->second;
+
+        // Reject if message is not strictly newer
+        if (msg.timestamp <= cached.timestamp) {
+            return false;
+        }
+
+        // If message has unknown aircraft type but cache has known types, apply the first
+        if (msg.aircraftType == OgnAircraftType::unknown &&
+            !cached.aircraftTypes.empty()) {
+            msg.aircraftType = *cached.aircraftTypes.begin();
+        }
+    }
+
+    // Update the cache with this new message
+    m_cache.update(msg);
+
+    // Message is new
+    return true;
+}
+
+} // namespace Ogn

--- a/lib/OgnFilter.h
+++ b/lib/OgnFilter.h
@@ -1,0 +1,124 @@
+/***************************************************************************
+ *   Copyright (C) 2021-2025 by Stefan Kebekus                             *
+ *   stefan.kebekus@gmail.com                                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#pragma once
+
+#include "OgnParser.h"
+
+#include <map>
+#include <set>
+#include <string>
+
+namespace Ogn {
+
+/*! \brief Persistent OGN data entry for a single aircraft.
+ *
+ *  Lightweight cache entry containing only the most relevant tracking data:
+ *  timestamp, aircraft type, address information, and call sign.
+ */
+struct OgnData {
+    std::chrono::system_clock::time_point timestamp; /*!< UTC time of the message */
+    std::set<OgnAircraftType> aircraftTypes;          /*!< all aircraft types seen (e.g. Glider, TowPlane) */
+    std::set<OgnAddressType> addressTypes;            /*!< all address types seen (e.g. ICAO, FLARM) */
+};
+
+
+/*! \brief Cache of OGN traffic data, keyed by aircraft ID.
+ *
+ *  Maintains a map from aircraftID to the most recent OgnData for that
+ *  aircraft. Feed incoming parsed messages via update().
+ */
+class OgnCache {
+    // std::map with std::less<> enables heterogeneous lookup in C++17:
+    // find() and insert() accept string_view without allocating a temporary string.
+    // Key: std::string (aircraft ID, e.g., "id0ADDE626")
+    // Value: OgnData (cached aircraft information including timestamp, type, address types)
+    using CacheMap = std::map<std::string, OgnData, std::less<>>;
+
+public:
+    /*! \brief Update the cache with data from a new OGN traffic message.
+     *
+     *  Processing rules:
+     *  - Only TRAFFIC_REPORT messages with a non-empty aircraftID are accepted.
+     *  - The stored entry is updated only if \p msg carries a strictly newer
+     *    timestamp than the cached one (epoch timestamp counts as "no data yet").
+     *  - Fields that carry no valid information are not overwritten:
+     *    - aircraftType: skipped when OgnAircraftType::unknown.
+     *    - addressType: added to the set of known address types.
+     *    - All string fields: skipped when empty.
+     *  - callSign is set to flightnumber when flightnumber is non-empty;
+     *    otherwise it is initialised from sourceId if not yet populated.
+     *
+     *  \param msg  A parsed OGN message (produced by OgnParser::parseAprsisMessage).
+     */
+    void update(const OgnMessage& msg);
+
+    /*! \brief Remove all cached entries with timestamps older than 1 hour.
+     *
+     *  This is useful to purge stale aircraft data from the cache.
+     *  Entries with an epoch timestamp (no valid data) are also removed.
+     */
+    void clean();
+
+    /*! \brief Read-only access to the internal map. */
+    const CacheMap& data() const { return m_cache; }
+
+private:
+    CacheMap m_cache;
+};
+
+
+/*! \brief Filter for OGN traffic messages based on timestamp and cached data.
+ *
+ *  Evaluates incoming OGN messages and determines if they contain new data
+ *  by comparing timestamps against a cached history. Also enriches messages
+ *  with previously known aircraft type information.
+ */
+class OgnFilter {
+public:
+    /*! \brief Evaluate a traffic message and update it based on cached data.
+     *
+     *  Processing rules:
+     *  - Only TRAFFIC_REPORT messages are accepted.
+     *  - Returns false (no new data) if the message timestamp is older than
+     *    or equal to what is cached for this aircraftID.
+     *  - If the message timestamp is strictly newer than the cached entry:
+     *    - If msg.aircraftType is unknown but the cache has a known type,
+     *      msg.aircraftType is updated from the cache.
+     *    - Returns true (new data).
+     *  - The cache is updated with the new message data.
+     *
+     *  \param msg  A parsed OGN message to filter and enrich. May be modified
+     *              if a known aircraft type is applied from cache.
+     *  \return     True if the message contains new data, false otherwise.
+     */
+    bool filter(OgnMessage& msg);
+
+    /*! \brief Remove all cached entries with timestamps older than 1 hour. */
+    void clean() { m_cache.clean(); }
+
+    /*! \brief Read-only access to the internal cache. */
+    const OgnCache& cache() const { return m_cache; }
+
+private:
+    OgnCache m_cache;
+};
+
+} // namespace Ogn

--- a/lib/OgnParser.cpp
+++ b/lib/OgnParser.cpp
@@ -352,8 +352,31 @@ void OgnParser::parseTrafficReport(OgnMessage& ognMessage, const std::string_vie
         return;
     }
 
-    // Parse timestamp
-    ognMessage.timestamp = aprsPart.substr(1, 6);
+    // Parse timestamp (hhmmss) into a UTC time_point
+    {
+        std::string_view const tsStr = aprsPart.substr(1, 6);
+        int h = 0, m = 0, s = 0;
+        std::from_chars(tsStr.data(),     tsStr.data() + 2, h);
+        std::from_chars(tsStr.data() + 2, tsStr.data() + 4, m);
+        std::from_chars(tsStr.data() + 4, tsStr.data() + 6, s);
+
+        // Compute start of current UTC day without heap allocation or gmtime
+        auto const now = std::chrono::system_clock::now();
+        auto const now_s = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+        auto const day_start = std::chrono::system_clock::time_point(
+            std::chrono::seconds(now_s - (now_s % 86400)));
+
+        auto tp = day_start
+            + std::chrono::hours(h)
+            + std::chrono::minutes(m)
+            + std::chrono::seconds(s);
+
+        // Handle day-boundary: if more than 12 hours in the future, it belongs to yesterday
+        if (tp > now + std::chrono::hours(12)) {
+            tp -= std::chrono::hours(24);
+        }
+        ognMessage.timestamp = tp;
+    }
 
     // Parse coordinates
     {

--- a/lib/OgnParser.h
+++ b/lib/OgnParser.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -132,7 +133,7 @@ struct OgnMessage
     OgnMessageType type = OgnMessageType::UNKNOWN; // e.g. OgnMessageType::TRAFFIC_REPORT
 
     std::string_view sourceId;       // like ENROUTE12345
-    std::string_view timestamp;      // hhmmss
+    std::chrono::system_clock::time_point timestamp; // UTC time of the message
     double latitude = std::numeric_limits<double>::quiet_NaN();  // Latitude in degrees (WGS84)
     double longitude = std::numeric_limits<double>::quiet_NaN(); // Longitude in degrees (WGS84)
     double altitude = std::numeric_limits<double>::quiet_NaN();  // Altitude in meters (MSL)
@@ -140,7 +141,7 @@ struct OgnMessage
 
     double course = {};         // course in degrees
     double speed = {};          // speed in knots
-    std::string_view aircraftID;     // aircraft ID, e.g. "id0ADDE626"
+    std::string_view aircraftID;     // aircraft ID in format idXXYYYYYY: XX encodes stealth/no-track/aircraftType/addressType; YYYYYY is the address
     double verticalSpeed = {};  // in m/s
     std::string_view rotationRate;   // like "+0.0rot"
     std::string_view signalStrength; // like "5.5dB"
@@ -168,7 +169,7 @@ struct OgnMessage
         sentence.clear();
         type = OgnMessageType::UNKNOWN;
         sourceId = std::string_view();       
-        timestamp = std::string_view();      
+        timestamp = std::chrono::system_clock::time_point{};
         latitude = std::numeric_limits<double>::quiet_NaN();
         longitude = std::numeric_limits<double>::quiet_NaN();
         altitude = std::numeric_limits<double>::quiet_NaN();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,3 +19,24 @@ target_compile_features(OgnParserTest PRIVATE cxx_std_17)
 # Register the test with CTest
 add_test(NAME OgnParserTest COMMAND OgnParserTest)
 
+# Add OgnFilter test executable
+add_executable(OgnFilterTest
+    OgnFilterTest.cpp
+    ../lib/OgnFilter.cpp
+    ../lib/OgnParser.cpp
+)
+
+# Include the source directory to find headers
+target_include_directories(OgnFilterTest
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../lib
+)
+
+# No Qt dependencies - uses only C++ standard library
+target_compile_features(OgnFilterTest PRIVATE cxx_std_17)
+
+# Register the test with CTest
+add_test(NAME OgnFilterTest COMMAND OgnFilterTest)
+
+

--- a/tests/OgnFilterTest.cpp
+++ b/tests/OgnFilterTest.cpp
@@ -1,0 +1,466 @@
+/***************************************************************************
+ *   Unit tests for OgnFilter and OgnCache                               *
+ ***************************************************************************/
+
+#include "OgnFilter.h"
+#include "OgnParser.h"
+#include "test_helpers.h"
+#include <iostream>
+#include <cmath>
+#include <chrono>
+#include <thread>
+#include <functional>
+
+using namespace Ogn;
+
+// Forward declarations
+bool testCacheUpdate_newEntry();
+bool testCacheUpdate_newerData();
+bool testCacheUpdate_olderData();
+bool testCacheUpdate_unknownAircraftType();
+bool testCacheUpdate_multipleAddressTypes();
+bool testCacheUpdate_multipleAircraftTypes();
+bool testCacheUpdate_ignoresNonTrafficReport();
+bool testCacheUpdate_ignoresEmptyAircraftID();
+bool testCacheClean_removeOldEntries();
+bool testFilterBasic_acceptNewData();
+bool testFilterBasic_rejectOldData();
+bool testFilterBasic_rejectEqualTimestamp();
+bool testFilterBasic_ignoresNonTrafficReport();
+bool testFilterBasic_ignoresEmptyAircraftID();
+bool testFilterEnrichment_applyKnownAircraftType();
+bool testFilterEnrichment_preserveUnknownType();
+
+// Test registry
+struct Test {
+    const char* name;
+    std::function<bool()> func;
+};
+
+const Test tests[] = {
+    {"testCacheUpdate_newEntry", testCacheUpdate_newEntry},
+    {"testCacheUpdate_newerData", testCacheUpdate_newerData},
+    {"testCacheUpdate_olderData", testCacheUpdate_olderData},
+    {"testCacheUpdate_unknownAircraftType", testCacheUpdate_unknownAircraftType},
+    {"testCacheUpdate_multipleAddressTypes", testCacheUpdate_multipleAddressTypes},
+    {"testCacheUpdate_multipleAircraftTypes", testCacheUpdate_multipleAircraftTypes},
+    {"testCacheUpdate_ignoresNonTrafficReport", testCacheUpdate_ignoresNonTrafficReport},
+    {"testCacheUpdate_ignoresEmptyAircraftID", testCacheUpdate_ignoresEmptyAircraftID},
+    {"testCacheClean_removeOldEntries", testCacheClean_removeOldEntries},
+    {"testFilterBasic_acceptNewData", testFilterBasic_acceptNewData},
+    {"testFilterBasic_rejectOldData", testFilterBasic_rejectOldData},
+    {"testFilterBasic_rejectEqualTimestamp", testFilterBasic_rejectEqualTimestamp},
+    {"testFilterBasic_ignoresNonTrafficReport", testFilterBasic_ignoresNonTrafficReport},
+    {"testFilterBasic_ignoresEmptyAircraftID", testFilterBasic_ignoresEmptyAircraftID},
+    {"testFilterEnrichment_applyKnownAircraftType", testFilterEnrichment_applyKnownAircraftType},
+    {"testFilterEnrichment_preserveUnknownType", testFilterEnrichment_preserveUnknownType},
+};
+
+// Cache stores a new aircraft entry correctly
+bool testCacheUpdate_newEntry() {
+    OgnCache cache;
+    OgnMessage msg;
+    msg.type = OgnMessageType::TRAFFIC_REPORT;
+    msg.aircraftID = "id0ADDE626";
+    msg.timestamp = std::chrono::system_clock::now();
+    msg.aircraftType = OgnAircraftType::Glider;
+    msg.addressType = OgnAddressType::FLARM;
+
+    cache.update(msg);
+
+    const auto& data = cache.data();
+    ASSERT_EQ(data.size(), size_t(1));
+    ASSERT_EQ(data.count("id0ADDE626"), size_t(1));
+
+    const auto& entry = data.at("id0ADDE626");
+    ASSERT_TRUE(entry.aircraftTypes.count(OgnAircraftType::Glider) > 0);
+    ASSERT_TRUE(entry.addressTypes.count(OgnAddressType::FLARM) > 0);
+
+    return true;
+}
+
+// Cache updates entry when newer timestamp is received
+bool testCacheUpdate_newerData() {
+    OgnCache cache;
+    auto now = std::chrono::system_clock::now();
+
+    // First update
+    OgnMessage msg1;
+    msg1.type = OgnMessageType::TRAFFIC_REPORT;
+    msg1.aircraftID = "id0ADDE626";
+    msg1.timestamp = now;
+    msg1.aircraftType = OgnAircraftType::Glider;
+    msg1.addressType = OgnAddressType::FLARM;
+    cache.update(msg1);
+
+    // Newer update
+    OgnMessage msg2;
+    msg2.type = OgnMessageType::TRAFFIC_REPORT;
+    msg2.aircraftID = "id0ADDE626";
+    msg2.timestamp = now + std::chrono::seconds(1);
+    msg2.aircraftType = OgnAircraftType::TowPlane;
+    msg2.addressType = OgnAddressType::ICAO;
+    cache.update(msg2);
+
+    const auto& data = cache.data();
+    const auto& entry = data.at("id0ADDE626");
+    ASSERT_TRUE(entry.aircraftTypes.count(OgnAircraftType::Glider) > 0);
+    ASSERT_TRUE(entry.aircraftTypes.count(OgnAircraftType::TowPlane) > 0);
+    ASSERT_TRUE(entry.addressTypes.count(OgnAddressType::FLARM) > 0);
+    ASSERT_TRUE(entry.addressTypes.count(OgnAddressType::ICAO) > 0);
+
+    return true;
+}
+
+// Cache ignores update with older timestamp
+bool testCacheUpdate_olderData() {
+    OgnCache cache;
+    auto now = std::chrono::system_clock::now();
+
+    // First update
+    OgnMessage msg1;
+    msg1.type = OgnMessageType::TRAFFIC_REPORT;
+    msg1.aircraftID = "id0ADDE626";
+    msg1.timestamp = now;
+    msg1.aircraftType = OgnAircraftType::Glider;
+    cache.update(msg1);
+
+    // Older update (should be ignored)
+    OgnMessage msg2;
+    msg2.type = OgnMessageType::TRAFFIC_REPORT;
+    msg2.aircraftID = "id0ADDE626";
+    msg2.timestamp = now - std::chrono::seconds(1);
+    msg2.aircraftType = OgnAircraftType::TowPlane;
+    cache.update(msg2);
+
+    const auto& data = cache.data();
+    const auto& entry = data.at("id0ADDE626");
+    // Older update ignored, only Glider should be in the set
+    ASSERT_TRUE(entry.aircraftTypes.count(OgnAircraftType::Glider) > 0);
+    ASSERT_EQ(entry.aircraftTypes.count(OgnAircraftType::TowPlane), size_t(0));
+
+    return true;
+}
+
+// Cache preserves known aircraft type when unknown type is received
+bool testCacheUpdate_unknownAircraftType() {
+    OgnCache cache;
+    auto now = std::chrono::system_clock::now();
+
+    // First update with known type
+    OgnMessage msg1;
+    msg1.type = OgnMessageType::TRAFFIC_REPORT;
+    msg1.aircraftID = "id0ADDE626";
+    msg1.timestamp = now;
+    msg1.aircraftType = OgnAircraftType::Glider;
+    cache.update(msg1);
+
+    // Newer update with unknown type (should not overwrite)
+    OgnMessage msg2;
+    msg2.type = OgnMessageType::TRAFFIC_REPORT;
+    msg2.aircraftID = "id0ADDE626";
+    msg2.timestamp = now + std::chrono::seconds(1);
+    msg2.aircraftType = OgnAircraftType::unknown;
+    cache.update(msg2);
+
+    const auto& data = cache.data();
+    const auto& entry = data.at("id0ADDE626");
+    // Unknown type is not added; Glider should still be in the set
+    ASSERT_TRUE(entry.aircraftTypes.count(OgnAircraftType::Glider) > 0);
+    ASSERT_EQ(entry.aircraftTypes.size(), size_t(1));
+
+    return true;
+}
+
+// Cache accumulates multiple address types in a set
+bool testCacheUpdate_multipleAddressTypes() {
+    OgnCache cache;
+    auto now = std::chrono::system_clock::now();
+
+    // First update with FLARM
+    OgnMessage msg1;
+    msg1.type = OgnMessageType::TRAFFIC_REPORT;
+    msg1.aircraftID = "id0ADDE626";
+    msg1.timestamp = now;
+    msg1.addressType = OgnAddressType::FLARM;
+    cache.update(msg1);
+
+    // Second update with ICAO
+    OgnMessage msg2;
+    msg2.type = OgnMessageType::TRAFFIC_REPORT;
+    msg2.aircraftID = "id0ADDE626";
+    msg2.timestamp = now + std::chrono::seconds(1);
+    msg2.addressType = OgnAddressType::ICAO;
+    cache.update(msg2);
+
+    const auto& data = cache.data();
+    const auto& entry = data.at("id0ADDE626");
+    ASSERT_EQ(entry.addressTypes.size(), size_t(2));
+    ASSERT_TRUE(entry.addressTypes.count(OgnAddressType::FLARM) > 0);
+    ASSERT_TRUE(entry.addressTypes.count(OgnAddressType::ICAO) > 0);
+
+    return true;
+}
+
+// Cache cleanup removes entries older than 1 hour
+bool testCacheClean_removeOldEntries() {
+    OgnCache cache;
+    auto now = std::chrono::system_clock::now();
+    auto old_time = now - std::chrono::hours(2);
+    auto recent_time = now - std::chrono::minutes(10);
+
+    // Add old entry
+    OgnMessage msg_old;
+    msg_old.type = OgnMessageType::TRAFFIC_REPORT;
+    msg_old.aircraftID = "id0ADDE626";
+    msg_old.timestamp = old_time;
+    msg_old.aircraftType = OgnAircraftType::Glider;
+    cache.update(msg_old);
+
+    // Add recent entry
+    OgnMessage msg_recent;
+    msg_recent.type = OgnMessageType::TRAFFIC_REPORT;
+    msg_recent.aircraftID = "id0BBBBBB";
+    msg_recent.timestamp = recent_time;
+    msg_recent.aircraftType = OgnAircraftType::TowPlane;
+    cache.update(msg_recent);
+
+    ASSERT_EQ(cache.data().size(), size_t(2));
+
+    cache.clean();
+
+    // Old entry should be removed, recent entry should remain
+    ASSERT_EQ(cache.data().size(), size_t(1));
+    ASSERT_EQ(cache.data().count("id0BBBBBB"), size_t(1));
+    ASSERT_EQ(cache.data().count("id0ADDE626"), size_t(0));
+
+    return true;
+}
+
+// Cache accumulates multiple aircraft types in a set
+bool testCacheUpdate_multipleAircraftTypes() {
+    OgnCache cache;
+    auto now = std::chrono::system_clock::now();
+
+    OgnMessage msg1;
+    msg1.type = OgnMessageType::TRAFFIC_REPORT;
+    msg1.aircraftID = "id0ADDE626";
+    msg1.timestamp = now;
+    msg1.aircraftType = OgnAircraftType::Glider;
+    cache.update(msg1);
+
+    OgnMessage msg2;
+    msg2.type = OgnMessageType::TRAFFIC_REPORT;
+    msg2.aircraftID = "id0ADDE626";
+    msg2.timestamp = now + std::chrono::seconds(1);
+    msg2.aircraftType = OgnAircraftType::TowPlane;
+    cache.update(msg2);
+
+    const auto& entry = cache.data().at("id0ADDE626");
+    ASSERT_EQ(entry.aircraftTypes.size(), size_t(2));
+    ASSERT_TRUE(entry.aircraftTypes.count(OgnAircraftType::Glider) > 0);
+    ASSERT_TRUE(entry.aircraftTypes.count(OgnAircraftType::TowPlane) > 0);
+
+    return true;
+}
+
+// Cache ignores non-TRAFFIC_REPORT messages
+bool testCacheUpdate_ignoresNonTrafficReport() {
+    OgnCache cache;
+    OgnMessage msg;
+    msg.type = OgnMessageType::COMMENT;
+    msg.aircraftID = "id0ADDE626";
+    msg.timestamp = std::chrono::system_clock::now();
+    cache.update(msg);
+
+    ASSERT_EQ(cache.data().size(), size_t(0));
+
+    return true;
+}
+
+// Cache ignores messages with empty aircraftID
+bool testCacheUpdate_ignoresEmptyAircraftID() {
+    OgnCache cache;
+    OgnMessage msg;
+    msg.type = OgnMessageType::TRAFFIC_REPORT;
+    msg.aircraftID = "";
+    msg.timestamp = std::chrono::system_clock::now();
+    cache.update(msg);
+
+    ASSERT_EQ(cache.data().size(), size_t(0));
+
+    return true;
+}
+
+// Filter accepts and caches new traffic report messages
+bool testFilterBasic_acceptNewData() {
+    OgnFilter filter;
+    OgnMessage msg;
+    msg.type = OgnMessageType::TRAFFIC_REPORT;
+    msg.aircraftID = "id0ADDE626";
+    msg.timestamp = std::chrono::system_clock::now();
+    msg.aircraftType = OgnAircraftType::Glider;
+
+    bool result = filter.filter(msg);
+    ASSERT_TRUE(result);
+
+    return true;
+}
+
+// Filter rejects messages with timestamp older than cached data
+bool testFilterBasic_rejectOldData() {
+    OgnFilter filter;
+    auto now = std::chrono::system_clock::now();
+
+    // First message
+    OgnMessage msg1;
+    msg1.type = OgnMessageType::TRAFFIC_REPORT;
+    msg1.aircraftID = "id0ADDE626";
+    msg1.timestamp = now;
+    msg1.aircraftType = OgnAircraftType::Glider;
+    filter.filter(msg1);
+
+    // Older message (should be rejected)
+    OgnMessage msg2;
+    msg2.type = OgnMessageType::TRAFFIC_REPORT;
+    msg2.aircraftID = "id0ADDE626";
+    msg2.timestamp = now - std::chrono::seconds(1);
+    msg2.aircraftType = OgnAircraftType::TowPlane;
+    
+    bool result = filter.filter(msg2);
+    ASSERT_FALSE(result);
+
+    return true;
+}
+
+// Filter rejects message with the same timestamp as cached (not strictly newer)
+bool testFilterBasic_rejectEqualTimestamp() {
+    OgnFilter filter;
+    auto now = std::chrono::system_clock::now();
+
+    OgnMessage msg1;
+    msg1.type = OgnMessageType::TRAFFIC_REPORT;
+    msg1.aircraftID = "id0ADDE626";
+    msg1.timestamp = now;
+    filter.filter(msg1);
+
+    OgnMessage msg2;
+    msg2.type = OgnMessageType::TRAFFIC_REPORT;
+    msg2.aircraftID = "id0ADDE626";
+    msg2.timestamp = now; // same timestamp
+
+    bool result = filter.filter(msg2);
+    ASSERT_FALSE(result);
+
+    return true;
+}
+
+// Filter returns false for non-TRAFFIC_REPORT messages
+bool testFilterBasic_ignoresNonTrafficReport() {
+    OgnFilter filter;
+    OgnMessage msg;
+    msg.type = OgnMessageType::COMMENT;
+    msg.aircraftID = "id0ADDE626";
+    msg.timestamp = std::chrono::system_clock::now();
+
+    bool result = filter.filter(msg);
+    ASSERT_FALSE(result);
+    ASSERT_EQ(filter.cache().data().size(), size_t(0));
+
+    return true;
+}
+
+// Filter returns false for messages with empty aircraftID
+bool testFilterBasic_ignoresEmptyAircraftID() {
+    OgnFilter filter;
+    OgnMessage msg;
+    msg.type = OgnMessageType::TRAFFIC_REPORT;
+    msg.aircraftID = "";
+    msg.timestamp = std::chrono::system_clock::now();
+
+    bool result = filter.filter(msg);
+    ASSERT_FALSE(result);
+    ASSERT_EQ(filter.cache().data().size(), size_t(0));
+
+    return true;
+}
+
+// Filter enriches message with cached aircraft type when message type is unknown
+bool testFilterEnrichment_applyKnownAircraftType() {
+    OgnFilter filter;
+    auto now = std::chrono::system_clock::now();
+
+    // First message with known type
+    OgnMessage msg1;
+    msg1.type = OgnMessageType::TRAFFIC_REPORT;
+    msg1.aircraftID = "id0ADDE626";
+    msg1.timestamp = now;
+    msg1.aircraftType = OgnAircraftType::Glider;
+    filter.filter(msg1);
+
+    // Second message with unknown type
+    OgnMessage msg2;
+    msg2.type = OgnMessageType::TRAFFIC_REPORT;
+    msg2.aircraftID = "id0ADDE626";
+    msg2.timestamp = now + std::chrono::seconds(1);
+    msg2.aircraftType = OgnAircraftType::unknown;
+    
+    bool result = filter.filter(msg2);
+    ASSERT_TRUE(result);
+    // Message should be enriched with cached aircraft type
+    ASSERT_EQ(static_cast<int>(msg2.aircraftType), static_cast<int>(OgnAircraftType::Glider));
+
+    return true;
+}
+
+// Filter preserves unknown type when cache has no known type
+bool testFilterEnrichment_preserveUnknownType() {
+    OgnFilter filter;
+    auto now = std::chrono::system_clock::now();
+
+    // First message with unknown type
+    OgnMessage msg1;
+    msg1.type = OgnMessageType::TRAFFIC_REPORT;
+    msg1.aircraftID = "id0ADDE626";
+    msg1.timestamp = now;
+    msg1.aircraftType = OgnAircraftType::unknown;
+    filter.filter(msg1);
+
+    // Second message with unknown type (cache also unknown, so stays unknown)
+    OgnMessage msg2;
+    msg2.type = OgnMessageType::TRAFFIC_REPORT;
+    msg2.aircraftID = "id0ADDE626";
+    msg2.timestamp = now + std::chrono::seconds(1);
+    msg2.aircraftType = OgnAircraftType::unknown;
+    
+    bool result = filter.filter(msg2);
+    ASSERT_TRUE(result);
+    // Message type should remain unknown
+    ASSERT_EQ(static_cast<int>(msg2.aircraftType), static_cast<int>(OgnAircraftType::unknown));
+
+    return true;
+}
+
+// Test runner
+int main() {
+    std::cout << "********* Start testing of OgnFilter *********" << std::endl;
+
+    int totalPassed = 0;
+    int totalFailed = 0;
+
+    for (const auto& test : tests) {
+        std::cout << "Running: " << test.name << " ... ";
+        if (test.func()) {
+            std::cout << "PASS" << std::endl;
+            totalPassed++;
+        } else {
+            std::cout << "FAIL" << std::endl;
+            totalFailed++;
+        }
+    }
+
+    std::cout << "\nTotals: " << totalPassed << " passed, " << totalFailed << " failed" << std::endl;
+    std::cout << "********* Finished testing of OgnFilter *********" << std::endl;
+
+    return totalFailed > 0 ? 1 : 0;
+}

--- a/tests/OgnParserTest.cpp
+++ b/tests/OgnParserTest.cpp
@@ -3,6 +3,7 @@
  ***************************************************************************/
 
 #include "OgnParser.h"
+#include "test_helpers.h"
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -15,43 +16,6 @@
 #include <functional>
 
 using namespace Ogn;
-
-// Simple test macros
-#define ASSERT_EQ(actual, expected) \
-    if ((actual) != (expected)) { \
-        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Expected " << (expected) << ", got " << (actual) << std::endl; \
-        return false; \
-    }
-
-#define ASSERT_DOUBLE_EQ(actual, expected) \
-    if (std::abs((actual) - (expected)) > 0.0000001) { \
-        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Expected " << (expected) << ", got " << (actual) << std::endl; \
-        return false; \
-    }
-
-#define ASSERT_GE(actual, min_val) \
-    if ((actual) < (min_val)) { \
-        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Expected >= " << (min_val) << ", got " << (actual) << std::endl; \
-        return false; \
-    }
-
-#define ASSERT_LE(actual, max_val) \
-    if ((actual) > (max_val)) { \
-        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Expected <= " << (max_val) << ", got " << (actual) << std::endl; \
-        return false; \
-    }
-
-#define ASSERT_TRUE(condition) \
-    if (!(condition)) { \
-        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Condition is false" << std::endl; \
-        return false; \
-    }
-
-#define ASSERT_NE(actual, unexpected) \
-    if ((actual) == (unexpected)) { \
-        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Values should not be equal: " << (actual) << std::endl; \
-        return false; \
-    }
 
 // Helper function to get current UTC time string
 std::string getCurrentUtcTimeString() {

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -9,145 +9,46 @@
 #include <cmath>
 #include <cstdlib>
 
-namespace TestHelpers {
-
-inline int testsPassed = 0;
-inline int testsFailed = 0;
-inline int testsSkipped = 0;
-inline std::string currentTest;
-
-#define TEST_CASE(name) \
-    void name(); \
-    struct name##_register { \
-        name##_register() { TestHelpers::registerTest(#name, name); } \
-    } name##_instance; \
-    void name()
-
-inline void fail(const std::string& message, const char* file, int line) {
-    std::cerr << "FAIL: " << currentTest << " - " << message 
-              << " (" << file << ":" << line << ")" << std::endl;
-    testsFailed++;
-    exit(1);
-}
-
-inline void pass(const std::string& message = "") {
-    if (!message.empty()) {
-        std::cout << "PASS: " << currentTest << " - " << message << std::endl;
+// Simple test macros for standalone testing
+#define ASSERT_EQ(actual, expected) \
+    if ((actual) != (expected)) { \
+        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Expected " << (expected) << ", got " << (actual) << std::endl; \
+        return false; \
     }
-}
 
-template<typename T>
-inline void assertEqual(const T& actual, const T& expected, const char* file, int line) {
-    if (actual != expected) {
-        std::cerr << "FAIL: " << currentTest << " - Expected: " << expected 
-                  << ", Got: " << actual << " (" << file << ":" << line << ")" << std::endl;
-        testsFailed++;
-        exit(1);
+#define ASSERT_DOUBLE_EQ(actual, expected) \
+    if (std::abs((actual) - (expected)) > 0.0000001) { \
+        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Expected " << (expected) << ", got " << (actual) << std::endl; \
+        return false; \
     }
-}
 
-inline void assertEqual(const std::string& actual, const std::string& expected, const char* file, int line) {
-    if (actual != expected) {
-        std::cerr << "FAIL: " << currentTest << " - Expected: \"" << expected 
-                  << "\", Got: \"" << actual << "\" (" << file << ":" << line << ")" << std::endl;
-        testsFailed++;
-        exit(1);
+#define ASSERT_GE(actual, min_val) \
+    if ((actual) < (min_val)) { \
+        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Expected >= " << (min_val) << ", got " << (actual) << std::endl; \
+        return false; \
     }
-}
 
-inline void assertEqual(double actual, double expected, const char* file, int line) {
-    if (std::abs(actual - expected) > 0.0000001) {
-        std::cerr << "FAIL: " << currentTest << " - Expected: " << expected 
-                  << ", Got: " << actual << " (" << file << ":" << line << ")" << std::endl;
-        testsFailed++;
-        exit(1);
+#define ASSERT_LE(actual, max_val) \
+    if ((actual) > (max_val)) { \
+        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Expected <= " << (max_val) << ", got " << (actual) << std::endl; \
+        return false; \
     }
-}
 
-inline void assertGreaterOrEqual(double actual, double expected, const char* file, int line) {
-    if (actual < expected) {
-        std::cerr << "FAIL: " << currentTest << " - Expected >= " << expected 
-                  << ", Got: " << actual << " (" << file << ":" << line << ")" << std::endl;
-        testsFailed++;
-        exit(1);
+#define ASSERT_TRUE(condition) \
+    if (!(condition)) { \
+        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Condition is false" << std::endl; \
+        return false; \
     }
-}
 
-inline void assertLessOrEqual(double actual, double expected, const char* file, int line) {
-    if (actual > expected) {
-        std::cerr << "FAIL: " << currentTest << " - Expected <= " << expected 
-                  << ", Got: " << actual << " (" << file << ":" << line << ")" << std::endl;
-        testsFailed++;
-        exit(1);
+#define ASSERT_FALSE(condition) \
+    if ((condition)) { \
+        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Condition is true" << std::endl; \
+        return false; \
     }
-}
 
-inline void assertNotEqual(int actual, int expected, const char* file, int line) {
-    if (actual == expected) {
-        std::cerr << "FAIL: " << currentTest << " - Values should not be equal: " << actual 
-                  << " (" << file << ":" << line << ")" << std::endl;
-        testsFailed++;
-        exit(1);
+#define ASSERT_NE(actual, unexpected) \
+    if ((actual) == (unexpected)) { \
+        std::cerr << "FAIL at " << __FILE__ << ":" << __LINE__ << ": Values should not be equal: " << (actual) << std::endl; \
+        return false; \
     }
-}
 
-inline void assertTrue(bool condition, const char* file, int line) {
-    if (!condition) {
-        std::cerr << "FAIL: " << currentTest << " - Condition is false"
-                  << " (" << file << ":" << line << ")" << std::endl;
-        testsFailed++;
-        exit(1);
-    }
-}
-
-inline void skip(const std::string& reason) {
-    std::cout << "SKIP: " << currentTest << " - " << reason << std::endl;
-    testsSkipped++;
-    exit(0);
-}
-
-using TestFunc = void(*)();
-inline std::vector<std::pair<std::string, TestFunc>>& getTests() {
-    static std::vector<std::pair<std::string, TestFunc>> tests;
-    return tests;
-}
-
-inline void registerTest(const std::string& name, TestFunc func) {
-    getTests().push_back({name, func});
-}
-
-inline int runAllTests() {
-    std::cout << "********* Start testing *********" << std::endl;
-    
-    for (const auto& [name, func] : getTests()) {
-        currentTest = name;
-        std::cout << "Running: " << name << std::endl;
-        
-        int result = system((std::string("./") + name).c_str());
-        if (result == 0) {
-            std::cout << "PASS: " << name << std::endl;
-            testsPassed++;
-        } else if (WEXITSTATUS(result) == 77) {  // Skip code
-            testsSkipped++;
-        } else {
-            testsFailed++;
-        }
-    }
-    
-    std::cout << "Totals: " << testsPassed << " passed, " 
-              << testsFailed << " failed, " 
-              << testsSkipped << " skipped" << std::endl;
-    std::cout << "********* Finished testing *********" << std::endl;
-    
-    return testsFailed > 0 ? 1 : 0;
-}
-
-} // namespace TestHelpers
-
-#define ASSERT_EQ(actual, expected) TestHelpers::assertEqual(actual, expected, __FILE__, __LINE__)
-#define ASSERT_NE(actual, expected) TestHelpers::assertNotEqual(actual, expected, __FILE__, __LINE__)
-#define ASSERT_GE(actual, expected) TestHelpers::assertGreaterOrEqual(actual, expected, __FILE__, __LINE__)
-#define ASSERT_LE(actual, expected) TestHelpers::assertLessOrEqual(actual, expected, __FILE__, __LINE__)
-#define ASSERT_TRUE(condition) TestHelpers::assertTrue(condition, __FILE__, __LINE__)
-#define SKIP_TEST(reason) TestHelpers::skip(reason)
-#define FAIL(message) TestHelpers::fail(message, __FILE__, __LINE__)


### PR DESCRIPTION
OgnFilter filters out messages with outdated timestamps and enriches them with cached aircraft type information. 
